### PR TITLE
Support running multiple servers in one script

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,1 +1,8 @@
-module.exports = require('./socks5');
+var Socks = require('./socks5');
+
+module.exports = Socks;
+
+module.exports.createServer = function (options) {
+  return new Socks(options);
+};
+

--- a/lib/socks5.js
+++ b/lib/socks5.js
@@ -63,15 +63,14 @@ var
  * https://www.ietf.org/rfc/rfc1929.txt - USERNAME/PASSWORD SOCKS5
  *
  **/
-module.exports = (function (self) {
+function __server (self) {
 	'use strict';
 
 	// local state
 	self.activeSessions = [];
-	self.options = {};
 	self.server = null;
 
-	function Session (socket) {
+  this.Session = function (socket) {
 
 		// Capture any unhandled errors
 		socket.on('error', function (err) {
@@ -362,17 +361,18 @@ module.exports = (function (self) {
 			self.activeSessions.splice(self.activeSessions.indexOf(socket), 1);
 		});
 	}
+}
 
-	/**
-	 * Creates a TCP SOCKS5 proxy server
-	 **/
-	self.createServer = function (options) {
-		self.options = options || {};
+/**
+ * Creates a TCP SOCKS5 proxy server
+ **/
+function SocksServer (options) {
+	var self = {};
+	self.options = options || {};
+	self.server = net.createServer((new __server(self)).Session);
 
-		self.server = net.createServer(Session);
+	return self.server;
+}
 
-		return self.server;
-	};
-
-	return self;
-}({}));
+module.exports = SocksServer;
+module.exports.events = EVENTS;


### PR DESCRIPTION
Currently if you create multiple servers in one script, then events will work only for the last created server.
It can be verified by running following example:
```
var socks5 = require('simple-socks');

var server1 = socks5.createServer();
server1.listen(1080);

var server2 = socks5.createServer();
server2.listen(1081);

server1.on('handshake', function (socket) {
  console.log('Server1: new socks5 client from %s:%d', socket.remoteAddress, socket.remotePort);
});

server2.on('handshake', function (socket) {
  console.log('Server2: new socks5 client from %s:%d', socket.remoteAddress, socket.remotePort);
});
```
Now no matter if you try to proxy via server1 or server2, you will get "Server2" messages in log.
```
curl https://www.google.com --socks5 127.0.0.1:1080
curl https://www.google.com --socks5 127.0.0.1:1081
```
This PR fixes the issue.


Also, this PR exposes events constants.
The example above could be changed like this:
```
server1.on(socks5.events.HANDSHAKE, function (socket) {
  console.log('Server1: new socks5 client from %s:%d', socket.remoteAddress, socket.remotePort);
});
```