### PR TITLE
Format ipv6 address properly

### DIFF
--- a/lib/socks5.js
+++ b/lib/socks5.js
@@ -191,9 +191,14 @@ function SocksServer (options) {
 							.word32be('addr.c')
 							.word32be('addr.d')
 							.tap(function (args) {
-								args.dst.addr = ['a', 'b', 'c', 'd'].map(function (x) {
-									return args.addr[x].toString(16);
-								});
+								let ipv6Parts = [];
+								for(let param of ['a', 'b', 'c', 'd']) {
+									let num = args.addr[param];
+									// each DWORD is converted to a pair of a WORD
+									ipv6Parts.push(((num & 0xffff0000) >> 16).toString(16));
+									ipv6Parts.push(((num & 0xffff)).toString(16));
+								}
+								args.dst.addr = ipv6Parts.join(":");
 							});
 
 					// unsupported address type


### PR DESCRIPTION
When connecting to a IPv6 site, the connection fails. The formatted address in a 4 strings array. For example, for "_fr.wikipedia.org_" which is "_2620:0:862:ed1a::1_", it gives _["26200000","862ed1a","0","1"]_.
With this modification, it will become _"2620:0:862:ed1a:0:0:0:1"_, which is not perfect (the three zeros could be removed) but (apparently) works.