### PR TITLE
Allow connection filtering

### DIFF
--- a/examples/createServerAllowConnection.js
+++ b/examples/createServerAllowConnection.js
@@ -3,10 +3,10 @@
 var
 	socks5 = require('../lib'),
 	server = socks5.createServer({
-        allow_connection : function (addr, port) {
+		allow_connection : function (addr, port) {
 			console.log('Not allowing to ' + addr);
-            return false;
-        }
+			return false;
+		}
 	});
 
 // start listening!

--- a/examples/createServerAllowConnection.js
+++ b/examples/createServerAllowConnection.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var
+	socks5 = require('../lib'),
+	server = socks5.createServer({
+        allow_connection : function (addr, port) {
+			console.log('Not allowing to ' + addr);
+            return false;
+        }
+	});
+
+// start listening!
+server.listen(1080);
+

--- a/lib/socks5.js
+++ b/lib/socks5.js
@@ -215,6 +215,10 @@ function SocksServer (options) {
 				.word16bu('dst.port')
 				.tap(function (args) {
 					if (args.cmd === RFC_1928_COMMANDS.CONNECT) {
+                        if(self.options.allow_connection && !self.options.allow_connection(args.dst.addr, args.dst.port)) {
+                            return end(RFC_1928_REPLIES.CONNECTION_REFUSED, args);
+						}
+
 						var destination = net.createConnection(
 							args.dst.port,
 							args.dst.addr,

--- a/lib/socks5.js
+++ b/lib/socks5.js
@@ -215,8 +215,8 @@ function SocksServer (options) {
 				.word16bu('dst.port')
 				.tap(function (args) {
 					if (args.cmd === RFC_1928_COMMANDS.CONNECT) {
-                        if(self.options.allow_connection && !self.options.allow_connection(args.dst.addr, args.dst.port)) {
-                            return end(RFC_1928_REPLIES.CONNECTION_REFUSED, args);
+						if (self.options.allow_connection && !self.options.allow_connection(args.dst.addr, args.dst.port)) {
+							return end(RFC_1928_REPLIES.CONNECTION_REFUSED, args);
 						}
 
 						var destination = net.createConnection(

--- a/readme.md
+++ b/readme.md
@@ -125,6 +125,19 @@ The authenticate callback accepts three arguments:
 * password - password of the proxy user
 * callback - callback for authentication... if authentication is successful, the callback should be called with no arguments
 
+## allow_connection
+
+Allows you to filter incoming connections, based on destination, return `false` to disallow:
+
+```javascript
+	server = socks5.createServer({
+        allow_connection : function (addr, port) {
+			console.log('Not allowing to ' + addr);
+            return false;
+        }
+	});
+```
+
 ## Events
 
 The socks5 server supports all events that exist on a native [net.Server](http://nodejs.org/api/net.html#net_class_net_server) object. Additionally, the following events have been added that are specific to the SOCKS5 proxy:

--- a/readme.md
+++ b/readme.md
@@ -130,12 +130,12 @@ The authenticate callback accepts three arguments:
 Allows you to filter incoming connections, based on destination, return `false` to disallow:
 
 ```javascript
-	server = socks5.createServer({
-        allow_connection : function (addr, port) {
-			console.log('Not allowing to ' + addr);
-            return false;
-        }
-	});
+server = socks5.createServer({
+    allow_connection : function (addr, port) {
+        console.log('Not allowing to ' + addr);
+        return false;
+    }
+});
 ```
 
 ## Events

--- a/readme.md
+++ b/readme.md
@@ -125,7 +125,7 @@ The authenticate callback accepts three arguments:
 * password - password of the proxy user
 * callback - callback for authentication... if authentication is successful, the callback should be called with no arguments
 
-## allow_connection
+#### allow_connection
 
 Allows you to filter incoming connections, based on destination, return `false` to disallow:
 

--- a/readme.md
+++ b/readme.md
@@ -138,6 +138,8 @@ server = socks5.createServer({
 });
 ```
 
+(see `examples/createServerAllowConnection.js`)
+
 ## Events
 
 The socks5 server supports all events that exist on a native [net.Server](http://nodejs.org/api/net.html#net_class_net_server) object. Additionally, the following events have been added that are specific to the SOCKS5 proxy:


### PR DESCRIPTION
This adds a `allow_connection` function to options, you can return true or false on whether you want to allow the connection to go through or not.

Thanks for the awesome app!