### PR TITLE
Wrong RFC version for constant

### DIFF
--- a/src/socks5.js
+++ b/src/socks5.js
@@ -218,7 +218,7 @@ class SocksServer {
 									err);
 
 								// respond with failure
-								return end(RFC_1929_REPLIES.CONNECTION_NOT_ALLOWED, args);
+								return end(RFC_1928_REPLIES.CONNECTION_NOT_ALLOWED, args);
 							});
 
 							// perform connection


### PR DESCRIPTION
https://github.com/brozeph/simple-socks/blob/ffa54304372c55fb97df31a8ccb5cb2cb22559fe/src/socks5.js#L221

The failure packet `CONNECTION_NOT_ALLOWED` doesn't exist on RFC_1929_REPLIES, it should be RFC_1928_REPLIES.