### PR TITLE
Add connectionOptions support to createServer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .nyc_output
 .vscode
 dist
+docs
 npm-debug.log
 lib-cov
 node_modules

--- a/history.md
+++ b/history.md
@@ -1,5 +1,31 @@
 # Changelog for simple-socks
 
+## v3.6.0 - 2026/05/02
+
+* Added `options.connectionOptions` to customize outbound TCP connection options before `net.createConnection`
+
+## v3.5.0 - 2026/03/16
+
+* Added `options.localAddress` and `options.localPort` support for outbound destination connections
+* Added `options.connectTimeout` to fail destination connections that do not complete within the configured timeout
+* Added `options.destinationIdleTimeout` to configure destination socket idle timeout separately from client socket idle timeout
+
+## v3.4.0 - 2026/03/08
+
+* Added `compatAuth` options for controlled RFC 1929 compatibility behavior
+* Added `compatAuth.allowEmptyUsername` and `compatAuth.allowEmptyPassword` options to relax empty credential validation when explicitly enabled
+* Added validation that `compatAuth.strictMethodNegotiation=false` is not supported
+* Documented macOS SOCKS client authentication limitations and compatibility guidance
+
+## v3.3.1 - 2026/03/08
+
+* Expanded integration-style SOCKS5 test coverage
+* Added tests for invalid handshakes, unsupported auth methods, BIND command handling, destination connection errors, `proxyData`, and socket teardown fallback behavior
+
+## v3.3.0 - 2026/03/08
+
+* Refreshed CI/CD tooling
+
 ## v3.2.0 - 2025/09/12
 
 * Removed gulp dev dependency

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { Server, Socket } from 'net';
+import { NetConnectOpts, Server, Socket } from 'net';
 
 export interface DestinationInfo {
 	address: string;
@@ -12,6 +12,10 @@ export interface OriginInfo {
 
 export type AuthenticateCallback = (err?: Error) => void;
 export type ConnectionFilterCallback = (err?: Error) => void;
+export type ConnectionOptionsCallback = (
+	err?: Error | null,
+	options?: NetConnectOpts,
+) => void;
 
 export type AuthenticateFn = (
 	username: string,
@@ -26,9 +30,17 @@ export type ConnectionFilterFn = (
 	callback: ConnectionFilterCallback,
 ) => void;
 
+export type ConnectionOptionsFn = (
+	destination: DestinationInfo,
+	origin: OriginInfo,
+	defaults: NetConnectOpts,
+	callback: ConnectionOptionsCallback,
+) => void;
+
 export interface Options {
 	authenticate?: AuthenticateFn;
 	connectionFilter?: ConnectionFilterFn;
+	connectionOptions?: ConnectionOptionsFn;
 	// Destroy sockets after this many ms of inactivity. 0 disables timeout.
 	idleTimeout?: number;
 	gssapi?: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simple-socks",
-  "version": "3.2.0",
+  "version": "3.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simple-socks",
-      "version": "3.2.0",
+      "version": "3.6.0",
       "license": "MIT",
       "dependencies": {
         "binary": "^0.3.0"
@@ -14,9 +14,12 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "c8": "^11.0.0",
-        "dprint": "^0.52.0",
-        "eslint": "^10.0.3",
-        "globals": "^17.4.0"
+        "dprint": "^0.54.0",
+        "eslint": "^10.3.0",
+        "globals": "^17.6.0"
+      },
+      "engines": {
+        "node": ">=16.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -30,9 +33,9 @@
       }
     },
     "node_modules/@dprint/darwin-arm64": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@dprint/darwin-arm64/-/darwin-arm64-0.52.0.tgz",
-      "integrity": "sha512-HHpmHCeFw1V9qUU0pJrz7LihrMgQJ5DOejfI3GRCJOd2ue3Api3/ZrzNSIqUbnx/j0RT5c7zxZR5aTE0RHwRFQ==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@dprint/darwin-arm64/-/darwin-arm64-0.54.0.tgz",
+      "integrity": "sha512-yqRI4enH+BDp+4+ZsPVdZM5h873JK1lN7li9l9A5u4C4cvh1oEsiBWAzEPccRkJ2ctF8LgaizBSxO38sqEVYbw==",
       "cpu": [
         "arm64"
       ],
@@ -44,9 +47,9 @@
       ]
     },
     "node_modules/@dprint/darwin-x64": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@dprint/darwin-x64/-/darwin-x64-0.52.0.tgz",
-      "integrity": "sha512-ZuoYH/hyzFhwwFUmykkm1QvLk9u7zxpKL6M8r1fY+lINucujIoGZxW1PjRbbIXaST6nDLbQB21P7LyNncAByOg==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@dprint/darwin-x64/-/darwin-x64-0.54.0.tgz",
+      "integrity": "sha512-W9BARpgHypcQwatg5mnHaCpX6pLX5dBxxiv+tZKruhOmq8MKYOrAYDXlceMuHSowmWREfUF5yL4SRgXDGI6WQw==",
       "cpu": [
         "x64"
       ],
@@ -58,9 +61,9 @@
       ]
     },
     "node_modules/@dprint/linux-arm64-glibc": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@dprint/linux-arm64-glibc/-/linux-arm64-glibc-0.52.0.tgz",
-      "integrity": "sha512-waghQcB32CLMuCxnVRQktc7U1S2qsL4spUmvCMyu4ufhZqXf4rQn07L1NcSmQOap40q9Db8ZBmLHfHm1Kab6uA==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@dprint/linux-arm64-glibc/-/linux-arm64-glibc-0.54.0.tgz",
+      "integrity": "sha512-VhM7p70VFuNqxZMdiv1e+nMboPj/hMFlTIBWrRaX7+6VThs9mJr9+94wrUeXgfnfsyaEKSbRFa/dru1PINoSNw==",
       "cpu": [
         "arm64"
       ],
@@ -72,9 +75,9 @@
       ]
     },
     "node_modules/@dprint/linux-arm64-musl": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@dprint/linux-arm64-musl/-/linux-arm64-musl-0.52.0.tgz",
-      "integrity": "sha512-8ml2DmF8i7eEou1G5nqgMMhRir89Fsd9cMLZRPZN/FSw6Nc3vAhk2MqZIrYk2DGfoWts7jis6XvEu3/TwMP8fw==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@dprint/linux-arm64-musl/-/linux-arm64-musl-0.54.0.tgz",
+      "integrity": "sha512-QS1A74Lv60/L9oemHCzbHgOLbV2smSJG5IxS5fjf8ZWetyUt918WDzIHBilz/+uiB+OlW2UVTsm952UG0YOrLw==",
       "cpu": [
         "arm64"
       ],
@@ -86,9 +89,9 @@
       ]
     },
     "node_modules/@dprint/linux-loong64-glibc": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@dprint/linux-loong64-glibc/-/linux-loong64-glibc-0.52.0.tgz",
-      "integrity": "sha512-tKj7Bwtcf/zNa1onoshYfQ8CaYz0N6BRYKsovop1H1d2dsRBYAKkR/FvTaPRJp1+Sx7Lc0RjRllFezkhLMRxPw==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@dprint/linux-loong64-glibc/-/linux-loong64-glibc-0.54.0.tgz",
+      "integrity": "sha512-8Myka2/0KbhuZnEKL6jagPXTgDKVpd/tfXDRa0oibUBgaqOSku6iRMzHGa/PhqHL+s14Gcp+/cIHz0zU3Tkgug==",
       "cpu": [
         "loong64"
       ],
@@ -100,9 +103,9 @@
       ]
     },
     "node_modules/@dprint/linux-loong64-musl": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@dprint/linux-loong64-musl/-/linux-loong64-musl-0.52.0.tgz",
-      "integrity": "sha512-8X+ICN/Pc4B+Zog2UXNDJph5uKLf0VVUItYEQbdbwqsWGzPa27Kqri5ainlFzaDs5TFkJHQKQlphg+TLyxBQ7A==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@dprint/linux-loong64-musl/-/linux-loong64-musl-0.54.0.tgz",
+      "integrity": "sha512-/AN3xCuMhC4PK7Pbj7/4zBuhFGr4m0OHV/5uGTfzpkKX/3+AXoyKl7PbT2VlNMGXAK0kuRThfjtx23gIwlWk7Q==",
       "cpu": [
         "loong64"
       ],
@@ -114,9 +117,9 @@
       ]
     },
     "node_modules/@dprint/linux-riscv64-glibc": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@dprint/linux-riscv64-glibc/-/linux-riscv64-glibc-0.52.0.tgz",
-      "integrity": "sha512-uQb2VqSnznfZHhrAKLxpjXMc7/c3AYepllVUhcGCdrTVp1fb7inHEilT2wSXUjOipBbfPG33cZWRzAgc5/Effg==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@dprint/linux-riscv64-glibc/-/linux-riscv64-glibc-0.54.0.tgz",
+      "integrity": "sha512-Aw2vXzzwFDpPbXh6ajsSabVCkCc66C3hCyMKprR/IxYvFtjYX80nh1ox0c7iaw6c4HacHMRLGw7FUSXvomPaEQ==",
       "cpu": [
         "riscv64"
       ],
@@ -128,9 +131,9 @@
       ]
     },
     "node_modules/@dprint/linux-x64-glibc": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@dprint/linux-x64-glibc/-/linux-x64-glibc-0.52.0.tgz",
-      "integrity": "sha512-Yh3fZYUcHmII+swTUh0qgf0lEPrz4+7v3tq+vqXR8/xa3Sx8QH5MQJsJDw8Ll1mmKX5HrkBNxA5rC1lIDuFn9g==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@dprint/linux-x64-glibc/-/linux-x64-glibc-0.54.0.tgz",
+      "integrity": "sha512-zZqj3wQELOX8n6QfT2uuWoMf64Wv0lMXNyam3btm+PKkg0P6a54TPL09Bs9XsViOdxgTcamsiQ7HlErt/LEjIA==",
       "cpu": [
         "x64"
       ],
@@ -142,9 +145,9 @@
       ]
     },
     "node_modules/@dprint/linux-x64-musl": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@dprint/linux-x64-musl/-/linux-x64-musl-0.52.0.tgz",
-      "integrity": "sha512-zdcgL6+PRjyZ4HVll9DuIn2ZnnxKuU0cwXtpfUZNdy+xRh1+OedUY5aZQRDN4163vkLxV9znXQT/TS0+giph1g==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@dprint/linux-x64-musl/-/linux-x64-musl-0.54.0.tgz",
+      "integrity": "sha512-it6Qdt06dyW2adbAXpOCb7/KQLxlm4i1UphUAWqWsZk4t3EYetyAza9J0g3Vu9itIWSEIo9MnccgANckQJ6+qw==",
       "cpu": [
         "x64"
       ],
@@ -156,9 +159,9 @@
       ]
     },
     "node_modules/@dprint/win32-arm64": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@dprint/win32-arm64/-/win32-arm64-0.52.0.tgz",
-      "integrity": "sha512-rQGhSbl2pcnU4Tl3xXJSPRi1smfIIf7XhVwzNOG7vcSExfcK8yYrrCS3z4VImYKqhI1kvv6gSfnIligtoyaX/g==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@dprint/win32-arm64/-/win32-arm64-0.54.0.tgz",
+      "integrity": "sha512-F5kjV/6I9YtNOTDWHUpTqM2HHHS510BPL7z4NJuU0nDnaVeks7GwNEltGr56CcsG8XQYhkiAsqZytPu6AhA2hQ==",
       "cpu": [
         "arm64"
       ],
@@ -170,9 +173,9 @@
       ]
     },
     "node_modules/@dprint/win32-x64": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@dprint/win32-x64/-/win32-x64-0.52.0.tgz",
-      "integrity": "sha512-Bi4kW6z9eVtRdNSztSvjjYET4SQzX/OYqsexVyppxv24m5RNOG1h+c9F5MFJpYy9LqQBAKHOQfkzQwPrdgNOXQ==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@dprint/win32-x64/-/win32-x64-0.54.0.tgz",
+      "integrity": "sha512-AAr2ye/DtgYXDplRoPS+5U++x7T6W4a3I9FvTFWFxziFmUptvAg5G2c4FcXoAduSruhYZJvjDZrLseR2c3IwXg==",
       "cpu": [
         "x64"
       ],
@@ -226,13 +229,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.3",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.3.tgz",
-      "integrity": "sha512-j+eEWmB6YYLwcNOdlwQ6L2OsptI/LO6lNBuLIqe5R7RetD658HLoF+Mn7LzYmAWWNNzdC6cqP+L6r8ujeYXWLw==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^3.0.3",
+        "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
         "minimatch": "^10.2.4"
       },
@@ -241,22 +244,22 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.3.tgz",
-      "integrity": "sha512-lzGN0onllOZCGroKJmRwY6QcEHxbjBw1gwB8SgRSqK8YbbtEXMvKynsXc3553ckIEBxsbMBU7oOZXKIPGZNeZw==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.5.tgz",
+      "integrity": "sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.1.1"
+        "@eslint/core": "^1.2.1"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.1.tgz",
-      "integrity": "sha512-QUPblTtE51/7/Zhfv8BDwO0qkkzQL7P/aWWbqcf4xWLEYn1oKjdO0gglQBB4GAsu7u6wjijbCmzsUTy6mnk6oQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -288,9 +291,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.3.tgz",
-      "integrity": "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -298,13 +301,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.1.tgz",
-      "integrity": "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
+      "integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.1.1",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -520,9 +523,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -669,27 +672,27 @@
       "license": "MIT"
     },
     "node_modules/dprint": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/dprint/-/dprint-0.52.0.tgz",
-      "integrity": "sha512-qXf3B6/G4E6SJKngfo7a0z1ja21o/JJ55cF8xyhyIqvJGrpJ96vhXLr37RrbWBWIj8eV+hquBkCAV6jCwenQYA==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/dprint/-/dprint-0.54.0.tgz",
+      "integrity": "sha512-sIy25poR2gRP/tWPTgP0MPeJoJcpv0xzYDcsboapvthbEt1Qw3Al252CA0xFyIh2cYEGGKyBJtKokryv4ERlJw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
-        "dprint": "bin.js"
+        "dprint": "bin.cjs"
       },
       "optionalDependencies": {
-        "@dprint/darwin-arm64": "0.52.0",
-        "@dprint/darwin-x64": "0.52.0",
-        "@dprint/linux-arm64-glibc": "0.52.0",
-        "@dprint/linux-arm64-musl": "0.52.0",
-        "@dprint/linux-loong64-glibc": "0.52.0",
-        "@dprint/linux-loong64-musl": "0.52.0",
-        "@dprint/linux-riscv64-glibc": "0.52.0",
-        "@dprint/linux-x64-glibc": "0.52.0",
-        "@dprint/linux-x64-musl": "0.52.0",
-        "@dprint/win32-arm64": "0.52.0",
-        "@dprint/win32-x64": "0.52.0"
+        "@dprint/darwin-arm64": "0.54.0",
+        "@dprint/darwin-x64": "0.54.0",
+        "@dprint/linux-arm64-glibc": "0.54.0",
+        "@dprint/linux-arm64-musl": "0.54.0",
+        "@dprint/linux-loong64-glibc": "0.54.0",
+        "@dprint/linux-loong64-musl": "0.54.0",
+        "@dprint/linux-riscv64-glibc": "0.54.0",
+        "@dprint/linux-x64-glibc": "0.54.0",
+        "@dprint/linux-x64-musl": "0.54.0",
+        "@dprint/win32-arm64": "0.54.0",
+        "@dprint/win32-x64": "0.54.0"
       }
     },
     "node_modules/emoji-regex": {
@@ -723,19 +726,19 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.3.tgz",
-      "integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
+      "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.3",
-        "@eslint/config-helpers": "^0.5.2",
-        "@eslint/core": "^1.1.1",
-        "@eslint/plugin-kit": "^0.6.1",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -746,7 +749,7 @@
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^9.1.2",
         "eslint-visitor-keys": "^5.0.1",
-        "espree": "^11.1.1",
+        "espree": "^11.2.0",
         "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -941,9 +944,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.0.tgz",
-      "integrity": "sha512-kC6Bb+ooptOIvWj5B63EQWkF0FEnNjV2ZNkLMLZRDDduIiWeFF4iKnslwhiWxjAdbg4NzTNo6h0qLuvFrcx+Sw==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -1006,9 +1009,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
-      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simple-socks",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "proxies requests ",
   "type": "module",
   "main": "src/socks5.js",

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "c8": "^11.0.0",
-    "dprint": "^0.52.0",
-    "eslint": "^10.0.3",
-    "globals": "^17.4.0"
+    "dprint": "^0.54.0",
+    "eslint": "^10.3.0",
+    "globals": "^17.6.0"
   },
   "dependencies": {
     "binary": "^0.3.0"

--- a/readme.md
+++ b/readme.md
@@ -179,6 +179,7 @@ This method accepts an optional `options` argument:
 
 - `options.authentication` - A callback for authentication
 - `options.connectionFilter` - A callback for connection filtering
+- `options.connectionOptions` - A callback for customizing outbound TCP connection options
 - `options.connectTimeout` - Milliseconds to wait for destination connect phase before failing the request (0 is disabled, default 0)
 - `options.idleTimeout` - Milliseconds of inactivity before destroying client/destination sockets (0 is disabled, default 0)
 - `options.destinationIdleTimeout` - Milliseconds of inactivity before destroying destination sockets; falls back to `options.idleTimeout` when not explicitly set
@@ -291,6 +292,100 @@ The `connectionFilter` callback accepts three arguments:
 - callback - callback for destination and/or origin address validation... if connections are allowed to the destination address, the callback should be called with no arguments
 
 For an example, see [examples/createServerConnectionFilter.js](examples/createServerConnectionFilter.js).
+
+#### connectionOptions callback
+
+Allows you to customize the options passed to `net.createConnection` after a request passes `connectionFilter`. This callback can rewrite the outbound destination, choose a local bind address, or route traffic through a local TCP adapter. It must return TCP connection options; it does not replace the destination with an arbitrary stream.
+
+```javascript
+import socks5 from "simple-socks";
+
+const server = socks5.createServer({
+  connectionOptions(destination, origin, defaults, callback) {
+    return callback(null, {
+      ...defaults,
+      host: "127.0.0.1",
+      port: destination.port === 443 ? 8443 : destination.port,
+    });
+  },
+});
+```
+
+The `connectionOptions` callback accepts four arguments:
+
+- destination - an information object containing details for the requested destination connection
+  - address - the TCP address of the remote server
+  - port - the TCP port of the remote server
+- origin - an information object containing details for origin connection
+  - address - the TCP address of the origin (client) connection
+  - port - the TCP port of the origin (client) connection
+- defaults - the options object the server would normally pass to `net.createConnection`
+  - host - the requested destination address
+  - port - the requested destination port
+  - localAddress - the configured local address, if provided
+  - localPort - the configured local port, if provided
+- callback - callback for returning an error or the final `net.createConnection` options
+
+To route requests through an SSH tunnel while keeping `simple-socks` responsible for creating a real `net.Socket`, bridge each request through a temporary local TCP listener. The listener accepts the socket created by `simple-socks`, then pipes it to the SSH channel returned by `forwardOut`:
+
+```javascript
+import net from "net";
+import socks5 from "simple-socks";
+
+function createSshForwardTarget(ssh, destination, origin, callback) {
+  const forwarder = net.createServer((localSocket) => {
+    forwarder.close();
+
+    ssh.forwardOut(
+      origin.address,
+      origin.port,
+      destination.address,
+      destination.port,
+      (err, sshStream) => {
+        if (err) {
+          localSocket.destroy(err);
+          return;
+        }
+
+        localSocket.pipe(sshStream);
+        sshStream.pipe(localSocket);
+
+        localSocket.once("close", () => sshStream.destroy());
+        localSocket.once("error", () => sshStream.destroy());
+        sshStream.once("close", () => localSocket.destroy());
+        sshStream.once("error", () => localSocket.destroy());
+      },
+    );
+  });
+
+  forwarder.once("error", callback);
+  forwarder.listen(0, "127.0.0.1", () => {
+    const address = forwarder.address();
+
+    callback(null, {
+      host: address.address,
+      port: address.port,
+    });
+  });
+}
+
+const server = socks5.createServer({
+  connectionOptions(destination, origin, defaults, callback) {
+    createSshForwardTarget(ssh, destination, origin, (err, target) => {
+      if (err) {
+        return callback(err);
+      }
+
+      return callback(null, {
+        ...defaults,
+        ...target,
+      });
+    });
+  },
+});
+```
+
+This pattern keeps the SOCKS server's outbound side TCP-based. If you already have a `stream.Duplex` from an SSH client or another transport, adapt it behind a local TCP listener instead of returning the stream directly.
 
 ### Multiple Interfaces
 

--- a/src/socks5.js
+++ b/src/socks5.js
@@ -323,70 +323,6 @@ class SocksServer {
 									port: socket.remotePort,
 								},
 								connectionFilterDomain.intercept(() => {
-									const destination = net.createConnection(
-										{
-											host: args.dst.addr,
-											localAddress: self.options.localAddress,
-											localPort: self.options.localPort,
-											port: args.dst.port,
-										},
-										() => {
-											// prepare a success response
-											const responseBuffer = Buffer.alloc(
-												args.requestBuffer.length,
-											);
-											args.requestBuffer.copy(responseBuffer);
-											responseBuffer[1] = RFC_1928_REPLIES.SUCCEEDED;
-
-											// write acknowledgement to client...
-											socket.write(responseBuffer, () => {
-												// listen for data bi-directionally
-												destination.pipe(socket);
-												socket.pipe(destination);
-
-												// configure idle timeout for destination socket
-												if (
-													self.destinationIdleTimeout
-													&& typeof destination.setTimeout === 'function'
-												) {
-													destination.setTimeout(
-														self.destinationIdleTimeout,
-														() => {
-															try {
-																destination.destroy(
-																	new Error('destination idle timeout'),
-																);
-															} catch {
-																// ignore socket destroy errors
-															}
-														},
-													);
-												}
-
-												// ensure proper teardown when either side ends/closes/errors
-												const teardownDestination = () => {
-													try {
-														destination.destroy();
-													} catch {
-														// ignore socket destroy errors
-													}
-												};
-												const teardownSocket = () => {
-													try {
-														socket.destroy();
-													} catch {
-														// ignore socket destroy errors
-													}
-												};
-
-												socket.once('close', teardownDestination);
-												socket.once('end', teardownDestination);
-												socket.once('error', teardownDestination);
-												destination.once('error', teardownSocket);
-											});
-										},
-									);
-
 									const destinationInfo = {
 										address: args.dst.addr,
 										port: args.dst.port,
@@ -395,82 +331,191 @@ class SocksServer {
 										address: socket.remoteAddress,
 										port: socket.remotePort,
 									};
+									const defaultConnectionOptions = {
+										host: args.dst.addr,
+										localAddress: self.options.localAddress,
+										localPort: self.options.localPort,
+										port: args.dst.port,
+									};
 
-									// capture successful connection
-									destination.on('connect', () => {
-										// emit connection event
-										self.server.emit(
-											EVENTS.PROXY_CONNECT,
-											destinationInfo,
-											destination,
-										);
-
-										// capture and emit proxied connection data
-										destination.on('data', (data) => {
-											self.server.emit(EVENTS.PROXY_DATA, data);
-										});
-
-										// capture close of destination and emit pending disconnect
-										// note: this event is only emitted once the destination socket is fully closed
-										destination.on('close', (hadError) => {
-											// indicate client connection end
-											self.server.emit(
-												EVENTS.PROXY_DISCONNECT,
-												originInfo,
-												destinationInfo,
-												hadError,
-											);
-										});
-
+									const failConnectionOptions = (err) => {
 										connectionFilterDomain.exit();
-									});
-
-									// capture connection errors and response appropriately
-									destination.on('error', (err) => {
-										// exit the connection filter domain
-										connectionFilterDomain.exit();
-
-										// notify of connection error
 										err.addr = args.dst.addr;
 										err.atyp = args.atyp;
 										err.port = args.dst.port;
-
 										self.server.emit(EVENTS.PROXY_ERROR, err);
-
-										if (err.code && err.code === 'EADDRNOTAVAIL') {
-											return end(RFC_1928_REPLIES.HOST_UNREACHABLE, args);
-										}
-
-										if (err.code && err.code === 'ECONNREFUSED') {
-											return end(RFC_1928_REPLIES.CONNECTION_REFUSED, args);
-										}
-
 										return end(RFC_1928_REPLIES.NETWORK_UNREACHABLE, args);
-									});
+									};
 
-									if (
-										self.connectTimeout
-										&& typeof destination.setTimeout === 'function'
-									) {
-										const onConnectTimeout = () => {
-											const timeoutError = new Error('destination connect timeout');
-											timeoutError.code = 'ETIMEDOUT';
-											try {
-												destination.destroy(timeoutError);
-											} catch {
-												// ignore socket destroy errors
-											}
-										};
+									const connectDestination = (connectionOptions) => {
+										if (
+											connectionOptions
+											&& typeof connectionOptions !== 'object'
+										) {
+											return failConnectionOptions(
+												new TypeError('connectionOptions must be an object'),
+											);
+										}
 
-										destination.setTimeout(self.connectTimeout);
-										destination.once('timeout', onConnectTimeout);
-										destination.once('connect', () => {
-											destination.off('timeout', onConnectTimeout);
-											if (!self.destinationIdleTimeout) {
-												destination.setTimeout(0);
-											}
+										const finalConnectionOptions = connectionOptions
+											|| defaultConnectionOptions;
+										const destination = net.createConnection(
+											finalConnectionOptions,
+											() => {
+												// prepare a success response
+												const responseBuffer = Buffer.alloc(
+													args.requestBuffer.length,
+												);
+												args.requestBuffer.copy(responseBuffer);
+												responseBuffer[1] = RFC_1928_REPLIES.SUCCEEDED;
+
+												// write acknowledgement to client...
+												socket.write(responseBuffer, () => {
+													// listen for data bi-directionally
+													destination.pipe(socket);
+													socket.pipe(destination);
+
+													// configure idle timeout for destination socket
+													if (
+														self.destinationIdleTimeout
+														&& typeof destination.setTimeout === 'function'
+													) {
+														destination.setTimeout(
+															self.destinationIdleTimeout,
+															() => {
+																try {
+																	destination.destroy(
+																		new Error('destination idle timeout'),
+																	);
+																} catch {
+																	// ignore socket destroy errors
+																}
+															},
+														);
+													}
+
+													// ensure proper teardown when either side ends/closes/errors
+													const teardownDestination = () => {
+														try {
+															destination.destroy();
+														} catch {
+															// ignore socket destroy errors
+														}
+													};
+													const teardownSocket = () => {
+														try {
+															socket.destroy();
+														} catch {
+															// ignore socket destroy errors
+														}
+													};
+
+													socket.once('close', teardownDestination);
+													socket.once('end', teardownDestination);
+													socket.once('error', teardownDestination);
+													destination.once('error', teardownSocket);
+												});
+											},
+										);
+
+										// capture successful connection
+										destination.on('connect', () => {
+											// emit connection event
+											self.server.emit(
+												EVENTS.PROXY_CONNECT,
+												destinationInfo,
+												destination,
+											);
+
+											// capture and emit proxied connection data
+											destination.on('data', (data) => {
+												self.server.emit(EVENTS.PROXY_DATA, data);
+											});
+
+											// capture close of destination and emit pending disconnect
+											// note: this event is only emitted once the destination socket is fully closed
+											destination.on('close', (hadError) => {
+												// indicate client connection end
+												self.server.emit(
+													EVENTS.PROXY_DISCONNECT,
+													originInfo,
+													destinationInfo,
+													hadError,
+												);
+											});
+
+											connectionFilterDomain.exit();
 										});
+
+										// capture connection errors and response appropriately
+										destination.on('error', (err) => {
+											// exit the connection filter domain
+											connectionFilterDomain.exit();
+
+											// notify of connection error
+											err.addr = args.dst.addr;
+											err.atyp = args.atyp;
+											err.port = args.dst.port;
+
+											self.server.emit(EVENTS.PROXY_ERROR, err);
+
+											if (err.code && err.code === 'EADDRNOTAVAIL') {
+												return end(RFC_1928_REPLIES.HOST_UNREACHABLE, args);
+											}
+
+											if (err.code && err.code === 'ECONNREFUSED') {
+												return end(RFC_1928_REPLIES.CONNECTION_REFUSED, args);
+											}
+
+											return end(RFC_1928_REPLIES.NETWORK_UNREACHABLE, args);
+										});
+
+										if (
+											self.connectTimeout
+											&& typeof destination.setTimeout === 'function'
+										) {
+											const onConnectTimeout = () => {
+												const timeoutError = new Error('destination connect timeout');
+												timeoutError.code = 'ETIMEDOUT';
+												try {
+													destination.destroy(timeoutError);
+												} catch {
+													// ignore socket destroy errors
+												}
+											};
+
+											destination.setTimeout(self.connectTimeout);
+											destination.once('timeout', onConnectTimeout);
+											destination.once('connect', () => {
+												destination.off('timeout', onConnectTimeout);
+												if (!self.destinationIdleTimeout) {
+													destination.setTimeout(0);
+												}
+											});
+										}
+									};
+
+									if (typeof self.options.connectionOptions !== 'function') {
+										return connectDestination(defaultConnectionOptions);
 									}
+
+									const connectionOptionsDomain = domain.create();
+									connectionOptionsDomain.on('error', failConnectionOptions);
+									return connectionOptionsDomain.run(() => {
+										self.options.connectionOptions(
+											destinationInfo,
+											originInfo,
+											{
+												...defaultConnectionOptions,
+											},
+											connectionOptionsDomain.intercept((connectionOptions) => {
+												connectionOptionsDomain.exit();
+												return connectDestination(
+													connectionOptions || defaultConnectionOptions,
+												);
+											}),
+										);
+									});
 								}),
 							);
 						} else {

--- a/test/index.js
+++ b/test/index.js
@@ -279,6 +279,85 @@ await test('connectTimeout fails destination connection when connect phase is to
 	}
 });
 
+await test('connectionOptions rewrites outbound host and port', async () => {
+	const echo = await createEchoServer();
+	const app = socks5.createServer({
+		connectionOptions(destination, origin, defaults, callback) {
+			assert.strictEqual(destination.address, '127.0.0.1');
+			assert.strictEqual(destination.port, 9);
+			assert.strictEqual(origin.address, '127.0.0.1');
+			assert.strictEqual(defaults.host, destination.address);
+			assert.strictEqual(defaults.port, destination.port);
+
+			return setImmediate(callback, null, {
+				...defaults,
+				host: echo.host,
+				port: echo.port,
+			});
+		},
+	});
+	await listenServer(app);
+	const addr = app.address();
+	const client = await connectTo(addr.port, addr.address);
+
+	client.write(buildSocks5Handshake(0x00));
+	const selection = await readExactly(client, 2);
+	assert.strictEqual(selection[0], 0x05);
+	assert.strictEqual(selection[1], 0x00);
+
+	client.write(buildSocks5ConnectRequest('127.0.0.1', 9));
+	const response = await readExactly(client, 2);
+	assert.strictEqual(response[0], 0x05);
+	assert.strictEqual(response[1], 0x00);
+
+	const payload = Buffer.from('rewritten destination');
+	client.write(payload);
+	const echoed = await readExactly(client, payload.length);
+	assert.strictEqual(Buffer.compare(echoed, payload), 0);
+
+	client.destroy();
+	await closeServer(app);
+	await closeServer(echo.server);
+});
+
+await test('connectionOptions error fails request before opening destination socket', async () => {
+	const app = socks5.createServer({
+		connectionOptions(_destination, _origin, _defaults, callback) {
+			return setImmediate(callback, new Error('cannot prepare connection options'));
+		},
+	});
+	await listenServer(app);
+	const addr = app.address();
+	const client = await connectTo(addr.port, addr.address);
+
+	client.write(buildSocks5Handshake(0x00));
+	const selection = await readExactly(client, 2);
+	assert.strictEqual(selection[0], 0x05);
+	assert.strictEqual(selection[1], 0x00);
+
+	const originalCreateConnection = net.createConnection;
+	try {
+		net.createConnection = () => {
+			throw new Error('net.createConnection should not be called');
+		};
+
+		const proxyErrorPromise = once(app, 'proxyError');
+		client.write(buildSocks5ConnectRequest('127.0.0.1', 80));
+		const response = await readExactly(client, 2);
+		assert.strictEqual(response[0], 0x05);
+		assert.strictEqual(response[1], 0x03);
+
+		const proxyError = await proxyErrorPromise;
+		assert.strictEqual(proxyError.message, 'cannot prepare connection options');
+		assert.strictEqual(proxyError.addr, '127.0.0.1');
+		assert.strictEqual(proxyError.port, 80);
+	} finally {
+		net.createConnection = originalCreateConnection;
+		client.destroy();
+		await closeServer(app);
+	}
+});
+
 await test('invalid handshake version returns general failure', async () => {
 	const app = socks5.createServer();
 	await listenServer(app);


### PR DESCRIPTION
This PR adds `options.connectionOptions` as a narrower alternative to accepting arbitrary `Duplex` streams from `connectionFilter`.

The intent is to keep `connectionFilter` focused on allow/deny policy while giving callers a separate hook to customize the outbound TCP dial. `simple-socks` still owns the call to `net.createConnection`, so existing socket lifecycle behavior, timeouts, piping, and proxy events remain under the library’s control.

This supports use cases like destination rewriting, local bind customization, and routing through a local TCP adapter. For SSH forwarding or other non-`net.Socket` transports, callers can bridge through a local TCP listener and return those listener options from `connectionOptions`, rather than returning the stream directly.

Included:
  - TypeScript declarations for `connectionOptions`
  - README documentation and SSH adapter example
  - tests for host/port rewriting and hook error handling
  - v3.6.0 changelog entry
  - dependency refresh and audit cleanup

To accomplish what #76 is trying to address:

```javascript
import net from "net";
import socks5 from "simple-socks";

// `ssh` is an already-connected ssh2 Client instance.
function createSshForwardTarget(ssh, destination, origin, callback) {
  const forwarder = net.createServer((localSocket) => {
    // This listener is for one SOCKS request only.
    forwarder.close();

    ssh.forwardOut(
      origin.address,
      origin.port,
      destination.address,
      destination.port,
      (err, sshStream) => {
        if (err) {
          localSocket.destroy(err);
          return;
        }

        localSocket.pipe(sshStream);
        sshStream.pipe(localSocket);

        localSocket.once("close", () => sshStream.destroy());
        localSocket.once("error", () => sshStream.destroy());
        sshStream.once("close", () => localSocket.destroy());
        sshStream.once("error", () => localSocket.destroy());
      },
    );
  });

  forwarder.once("error", callback);

  forwarder.listen(0, "127.0.0.1", () => {
    const address = forwarder.address();

    callback(null, {
      host: address.address,
      port: address.port,
    });
  });
}

const server = socks5.createServer({
  connectionOptions(destination, origin, defaults, callback) {
    createSshForwardTarget(ssh, destination, origin, (err, target) => {
      if (err) {
        return callback(err);
      }

      return callback(null, {
        ...defaults,
        ...target,
      });
    });
  },
});

server.listen(1080, "127.0.0.1");
```